### PR TITLE
Fix organization ID helper import and email service

### DIFF
--- a/routes/public.js
+++ b/routes/public.js
@@ -370,11 +370,11 @@ router.post(
 				await client.query("COMMIT");
 
 				// If the user type is 'animation', send an email to the admin(s)
-				if (userType === "animation") {
-					// Import this function only when needed
-					const { sendAdminVerificationEmail } = require("../utils");
-					await sendAdminVerificationEmail(organizationId, fullName, email);
-				}
+                                if (userType === "animation") {
+                                        // Import this function only when needed
+                                        const { sendAdminVerificationEmail } = require("../services/emailService");
+                                        await sendAdminVerificationEmail(organizationId, fullName, email);
+                                }
 
 				const message = isVerified
 					? "Registration successful. You can now log in."

--- a/utils/organizationContext.js
+++ b/utils/organizationContext.js
@@ -2,7 +2,7 @@
 const jwt = require('jsonwebtoken');
 const { pool } = require('../config/database');
 const logger = require('../config/logger');
-const determineOrganizationId = require('../utils')
+const { determineOrganizationId } = require('../utils');
 
 /**
  * Determine organization ID from multiple sources with consistent priority


### PR DESCRIPTION
## Summary
- fix organizationContext to properly import determineOrganizationId
- send admin notification email from email service

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683f422fa1548324b7ae4fcc241156a8